### PR TITLE
使用macro替代ActionContext

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Thumbs.db
 .DS_Store
 *.swp
 *.gz
+.vscode

--- a/src/store.js
+++ b/src/store.js
@@ -8,212 +8,7 @@
 
 
 import EventTarget from 'mini-event/EventTarget';
-import {set, push, unshift, splice} from 'san-update';
 import parseName from './parse-name';
-
-/**
- * action 运行环境类，其实例对象作为 action 运行时的 this
- *
- * @class
- */
-class ActionContext {
-    /**
-     * 构造函数
-     *
-     * @param {Store} store 所属数据容器对象
-     * @param {string} name action的名称
-     */
-    constructor(store, name) {
-        this.store = store;
-        this.name = name;
-    }
-
-    /**
-     * dispatch 一个 action
-     *
-     * @param {string} name action名称
-     * @param {*} payload payload
-     */
-    dispatch(name, payload) {
-        this.store.dispatch(name, payload);
-    }
-
-    /**
-     * 在数据容器对象设置中设值
-     *
-     * @param {string} name 数据项的名称
-     * @param {*} value 数据项的值
-     */
-    set(name, value) {
-        let prop = parseName(name);
-
-        if (value !== this.store.get(prop)) {
-            this.store.raw = set(this.store.raw, prop, value);
-
-            let arg = {
-                change: 'set',
-                action: this.name,
-                value: value,
-                prop: prop
-            };
-            this.store.log(arg);
-            this.store.fire('change', arg);
-        }
-    }
-
-    /**
-     * 为数组的数据项 push 一条数据
-     *
-     * @param {string} name 数据项的名称
-     * @param {*} value 要push的数据
-     */
-    push(name, value) {
-        if (value != null) {
-            let prop = parseName(name);
-
-            this.store.raw = push(this.store.raw, prop, value);
-            let arg = {
-                change: 'push',
-                action: this.name,
-                value: value,
-                prop: prop
-            };
-
-            this.store.log(arg);
-            this.store.fire('change', arg);
-        }
-    }
-
-    /**
-     * 为数组的数据项 unshift 一条数据
-     *
-     * @param {string} name 数据项的名称
-     * @param {*} value 要unshift的数据
-     */
-    unshift(name, value) {
-        if (value != null) {
-            let prop = parseName(name);
-
-            this.store.raw = unshift(this.store.raw, prop, value);
-            let arg = {
-                change: 'unshift',
-                action: this.name,
-                value: value,
-                prop: prop
-            };
-
-            this.store.log(arg);
-            this.store.fire('change', arg);
-        }
-    }
-
-    /**
-     * 数组数据项的 pop 操作
-     *
-     * @param {string} name 数据项的名称
-     * @return {*}
-     */
-    pop(name) {
-        let prop = parseName(name);
-
-        let array = this.store.get(prop);
-        let arrayLen;
-        if (array instanceof Array && (arrayLen = array.length) > 0) {
-            let value = array[arrayLen - 1];
-
-            this.store.raw = splice(this.store.raw, prop, arrayLen - 1, 1);
-            let arg = {
-                change: 'pop',
-                action: this.name,
-                value: value,
-                prop: prop
-            };
-
-            this.store.log(arg);
-            this.store.fire('change', arg);
-
-            return value;
-        }
-    }
-
-    /**
-     * 数组数据项的 shift 操作
-     *
-     * @param {string} name 数据项的名称
-     * @return {*}
-     */
-    shift(name) {
-        let prop = parseName(name);
-
-        let array = this.store.get(prop);
-        if (array instanceof Array && array.length > 0) {
-            let value = array[0];
-
-            this.store.raw = splice(this.store.raw, prop, 0, 1);
-            let arg = {
-                change: 'shift',
-                action: this.name,
-                value: value,
-                prop: prop
-            };
-
-            this.store.log(arg);
-            this.store.fire('change', arg);
-
-            return value;
-        }
-    }
-
-    /**
-     * 根据 index 移除数组数据项的 item
-     *
-     * @param {string} name 数据项的名称
-     * @param {number} index 要移除项的index
-     */
-    removeAt(name, index) {
-        let prop = parseName(name);
-
-        let array = this.store.get(prop);
-        if (array instanceof Array && array.length > index) {
-            let value = array[index];
-
-            this.store.raw = splice(this.store.raw, prop, index, 1);
-            let arg = {
-                change: 'remove',
-                action: this.name,
-                value: value,
-                prop: prop,
-                index: index
-            };
-
-            this.store.log(arg);
-            this.store.fire('change', arg);
-
-            return value;
-        }
-    }
-
-    /**
-     * 移除数组数据项中的 item
-     *
-     * @param {string} name 数据项的名称
-     * @param {*} value 要移除的项
-     */
-    remove(name, value) {
-        let prop = parseName(name);
-
-        let array = this.store.get(prop);
-        if (array instanceof Array) {
-            let len = array.length;
-
-            while (len--) {
-                if (array[len] === value) {
-                    return this.removeAt(prop, len);
-                }
-            }
-        }
-    }
-}
 
 /**
  * Store 类，应用程序状态数据的容器
@@ -221,6 +16,7 @@ class ActionContext {
  * @class
  */
 export default class Store extends EventTarget {
+
     /**
      * 构造函数
      *
@@ -261,7 +57,7 @@ export default class Store extends EventTarget {
     /**
      * 添加一个 action
      *
-     * @param {string} name action的名称
+     * @param {string | Symbol} name action的名称
      * @param {Function} action action函数
      */
     addAction(name, action) {
@@ -277,22 +73,9 @@ export default class Store extends EventTarget {
     }
 
     /**
-     * 添加多个 action
-     *
-     * @param {Object} actions action集合对象。对象的key是action的name，value是action函数
-     */
-    addActions(actions) {
-        for (let key in actions) {
-            if (actions.hasOwnProperty(key)) {
-                this.addAction(key, actions[key]);
-            }
-        }
-    }
-
-    /**
      * action 的 dispatch 入口
      *
-     * @param {string} name action名称
+     * @param {string | Symbol} name action名称
      * @param {*} payload payload
      */
     dispatch(name, payload) {
@@ -301,8 +84,21 @@ export default class Store extends EventTarget {
         if (typeof action === 'function') {
             this.log('Action start: ' + name);
 
-            let context = new ActionContext(store, name);
-            action.call(context, payload);
+            let macro = action(payload, this.raw);
+            let update = macro.build();
+            let records = macro.unpack()[1];
+            this.raw = update(this.raw);
+
+            for (let record of records) {
+                let event = {
+                    change: record.type,
+                    value: record.value,
+                    prop: record.path,
+                    action: name
+                };
+                this.log(event);
+                this.fire('change', event);
+            }
 
             this.log('Action done: ' + name);
         }

--- a/src/util/defineLazyProperty.js
+++ b/src/util/defineLazyProperty.js
@@ -1,0 +1,18 @@
+import {isGetterAvailable} from './isGetterAvailable';
+
+const NO_CACHE = {};
+
+let memoize = get => {
+    let cache = NO_CACHE;
+    return () => {
+        if (cache === NO_CACHE) {
+            cache = get();
+        }
+
+        return cache;
+    };
+};
+
+export default isGetterAvailable
+    ? (o, key, get) => Object.defineProperty(o, key, {get: memoize(get)})
+    : (o, key, get) => o[key] = get();

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -1,0 +1,5 @@
+import isGetterAvailable from './isGetterAvailable';
+import defineLazyProperty from './defineLazyProperty';
+import visit from './visit';
+
+export {isGetterAvailable, defineLazyProperty, visit};

--- a/src/util/isGetterAvailable.js
+++ b/src/util/isGetterAvailable.js
@@ -1,0 +1,10 @@
+let result = false;
+
+if (Object.defineProperty) {
+    let o = {};
+    let get = () => result = true;
+    Object.defineProperty(o, 'x', {get});
+    o.x;
+}
+
+export default result;

--- a/src/util/visit.js
+++ b/src/util/visit.js
@@ -1,0 +1,1 @@
+export default (o, path) => path.reduce((result, property) => result[property], o);


### PR DESCRIPTION
这边只考虑使用macro这一个点，其它如subscribe/dispatch分离等问题后续再讨论

我的基本思路是每一个Action是一个`(payload, storeData) => macro`的函数（很多时候不需要用data所以参数是payload在前），返回一个[san-update#macro](https://github.com/ecomfe/san-update#使用macro构建更新函数)，注意这边返回的是macro本身而不是`macro.build()`之后的函数，差不多是这样：

```
import {macro} from 'san-update';

// 当然其实更推荐invoke而不是set
store.addAction('vote', ({count}, data) => macro().set('voteCount', data.voteCount + count));
store.addAction('newPost', ({post}) => macro().push('posts', post));
store.addAction('deletePost', ({index}) => macro().splice('posts', index, 1));

// 如果有固定不变的macro可以直接复用，减去每次构建macro的微量开销
const MACRO_SIGN_OUT = macro().set('currentUser', null);

store.addAction('signOut', () => MACRO_SIGN_OUT);
```    

随后san-update可以做一次升级，在macro上提供一个`unpack()`函数，返回当前macro中包含的所有指令，这大概只需要5行左右代码即可搞定，且是在macro生成的过程中记录的，对性能没有影响

这样做的好处是：

1. 让Action更干净，不需要单独的ActionContext作为`this`
2. 不需要ActionContext相关的代码，可以瘦身很多
3. 额外更新功能的支持不需要san-store升级ActionContext，只需要对san-update进行升级或者干脆以san-update的macro为接口自己实现出一个来，可扩展性会好很多
4. 当一个Action要进行多个更新的时候，由于san-update本身在构建macro的过程中就合并了所有的操作，所以只需要对当前数据进行一次更新，能减少多余的对象创建和遍历
5. 让san-update的相关功能让更多人知晓，传达出“构造操作而非执行操作”的思想，让应用程序开发人员好好想想对状态有哪些操作，把这些操作合在一起作为一个统一体来观察，而不是在任何时候胡乱的就执行更新分散在各处
6. 杜绝无法理解应用架构的人在Action中使用异步并在异步之后调用`ActionContext#set`修改store的数据，即强制保证Action的同步特征

至于少了`remove`和`removeAt`这两个，我觉得如果有比较大规模的需求在san-update加也不是问题，10行内的代码量

另外考虑到名称冲突的问题，我设计为允许使用`Symbol`作为Action的名称，但因此无法有`addActions`这个批量的功能了

我没保证代码可运行，仅讨论用