### PR TITLE
修改 umd 包名

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,7 @@ let config = {
         path: path.resolve(__dirname, 'dist'),
         filename: 'san-store.source.js',
         publicPath: '/dist',
-        library: 'san-store',
+        library: 'sanStore',
         libraryTarget: 'umd',
         umdNamedDefine: true
     },


### PR DESCRIPTION
和 [san-update](https://github.com/ecomfe/san-update/blob/master/gulpfile.js#L14) 保持格式一致，避免在 console 下必须以 `window['san-store']` 的方式调用（方便在线展示）