### PR TITLE
mapStates support Array like ["name", "age"...] && Add createMapperCo…

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -7,7 +7,7 @@
  */
 
 import Store from './store';
-import createConnector from './connect/createConnector';
+import {createConnector, createMapperConnector} from './connect/createConnector';
 import emitDevtool from './devtool/emitter';
 
 /**
@@ -33,5 +33,6 @@ export {Store};
 
 export let connect = {
     san: createConnector(store),
-    createConnector
+    createConnector,
+    createMapperConnector
 };


### PR DESCRIPTION
两个大的修改：
1. connect(mapStates, mapActions)(Comp) 第一个参数mapStates支持传递 Array。（目前第二个参数mapActions是支持的）
before：
connect({
  name: 'name', 
  age: 'age', 
  school: 'school'
})(comp)
--->
after:
connect(['name', 'age', 'school'])(comp)

2. 更改了connect内部逻辑，在 connect.san  connect.createConnector 的基础上，增加了connect.createMapperConnector。这个方法的加入，使 san-store 从 必须在运行前定义并初始化好 mappers 映射，改变为： 可以在 component 运行时 定义 mappers 映射。
现在支持在 San.defineComponent({comp}) 中定义 mappers，类似 Vuex 的 混入。


before: ------------>
必须在定义 component 和 store之前，就想好 这个component 需要依赖哪些数据，映射关系如何。
这在大型项目抽离公共基类时，非常麻烦，例如：
1. 因为要兼容IE8，所以不能用 san-router，所以需要做一些通用封装
2. 数据绑定、路由绑定、基础依赖和数据的处理抽离到公共的layout.js，这里面有统一的 import 、defineComponent 和 san component 的 attach 挂载操作。
3. 其他页面拆分为单独路由 如 center.js 、shop.js、user.js...等，这些都是 export 一个 对象，里面都是 san component 的参数，如 {initData:{..}, methods:{...}, watchers:{...}}

你可能已经看到问题所在了，layout.js 里面，在创建store 关联的时候，要关心一堆component业务内的数据依赖：
const connectStore = connect.createConnector(myStore);
const sanComp = connectStore({
    {...某个业务内的一堆 mapStatus}
},{
    {...某个业务内的一堆 mapActions}
})(san.defineComponent(comp));

而且，当我业务内（如user.js）需要用另一个store数据，我必须跳转到 layout.js 中的 mapStates、mapActions 对象中添加，然后再到 user.js 中用这些数据，而且 user.js中的数据来源不明。

当然你可以说我可以在框架层面封装一个批量生成 state 监听，并批量调用 addAction，并批量 add listerner 和 unlisten 的方法。但这不就是 connect 做的事情吗。所以我对它做了改造。

注意这个改造和 Vuex 并不一样。Vuex 说到底是利用了 computed。但是我看了一下 san-store 的实现，是直接做的 store 的 监听 和 component 重新赋值。所以这里我直接把相关操作全部抽离和扩展了一下。使之支持从 componentClass 里面直接获取 mapGetters mapStatus 和 mapActions 参数（也就是当你用 connect.createMapperConnector 链接 store 的时候，mapStatus 和 mapActions就成了保留关键字）。

after： ------------------->

在公共 layout.js 中，调用新提供的 connect.createMapperConnector 创建 connector：
const myApp = san.defineComponent(comp);
const connectStore = connect.createMapperConnector(storeData);
const sanComp = connectStore(myApp);   // 注意这里不需要2步调用，只需要一步，传递compClass对象或者compFunction即可。
new sanComp().attach('#app');

在 user.js  page.js  shop.js 中，我可以用：
{
    mapStatus: ['age', 'name', 'school'],
    mapActions: ['setAge', 'setSchool'],
    template: __inline('./user.pug'),
    initdata: {},
    methods: {},
    ...其他逻辑
}
这样做有三个好处：
1. layout.js 在 connect Store 和 ComponentClass 时，无需关注我要关联哪些业务数据，这些东西在业务方js文件里关心就行了。
2. 业务方的 js 文件里面，哪些是自己的initdata，哪些是关联的store，哪些是computed，来源清晰明了，不需要来回跳着找数据来源
3. 运行时添加，不需要在 声明和绑定 store 的时候还关心 comp 内部的 store 依赖。

当然也有一个弊端，上面我也说到了，不同于vuex 的 computed 方式，基于 san-store 本身的实现方案，我想到的就是这种办法，用户如果这么使用，就必须认可这几个关键字的占用，需要在文档中写清楚。
