### PR TITLE
支持 san-devtool 监听异步 action

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "san-store",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/store.js
+++ b/src/store.js
@@ -182,6 +182,10 @@ export default class Store {
         let updateInfo;
         if (actionReturn) {
             if (typeof actionReturn.then === 'function') {
+                emitDevtool('store-dispatch-start', {
+                    store: this,
+                    actionInfo: this.actionCtrl.getById(actionId)
+                });
                 return actionReturn.then(returns => {
                     this.actionCtrl.done(actionId);
                     return returns;
@@ -204,11 +208,6 @@ export default class Store {
                 }
             }
         }
-        emitDevtool('store-dispatch-start', {
-            store: this,
-            diff: updateInfo ? updateInfo[1] : null,
-            actionInfo: this.actionCtrl.getById(actionId)
-        });
         this.actionCtrl.done(actionId);
 
         if (updateInfo) {
@@ -289,14 +288,13 @@ class ActionControl {
 
         if (childsDone && actionInfo.selfDone) {
             actionInfo.done = true;
+            if (this.store.log) {
+                actionInfo.endTime = (new Date()).getTime()
+            }
             emitDevtool('store-dispatch-done', {
                 store: this.store,
                 actionInfo
             });
-            if (this.store.log) {
-                actionInfo.endTime = (new Date()).getTime()
-            }
-
             if (actionInfo.parentId) {
                 this.detectDone(actionInfo.parentId);
             }

--- a/src/store.js
+++ b/src/store.js
@@ -173,7 +173,6 @@ export default class Store {
         }
 
         this.actionCtrl.start(actionId, name, payload, parentId);
-
         let context = {
             getState: name => this.getState(name),
             dispatch: (name, payload) => this._dispatch(name, payload, actionId)
@@ -205,20 +204,16 @@ export default class Store {
                 }
             }
         }
-
+        emitDevtool('store-dispatch-start', {
+            store: this,
+            diff: updateInfo ? updateInfo[1] : null,
+            actionInfo: this.actionCtrl.getById(actionId)
+        });
         this.actionCtrl.done(actionId);
 
         if (updateInfo) {
             this._fire(updateInfo[1]);
         }
-        emitDevtool('store-dispatched', {
-            store: this,
-            diff: updateInfo ? updateInfo[1] : null,
-            name,
-            payload,
-            actionId,
-            parentId
-        });
     }
 }
 
@@ -294,7 +289,10 @@ class ActionControl {
 
         if (childsDone && actionInfo.selfDone) {
             actionInfo.done = true;
-
+            emitDevtool('store-dispatch-done', {
+                store: this.store,
+                actionInfo
+            });
             if (this.store.log) {
                 actionInfo.endTime = (new Date()).getTime()
             }


### PR DESCRIPTION
背景：

目前，由于 san-store 在异步 action 触发的时候并不会通过 emitDevtool 通知到 san-devtool，导致当前  san-devtool 无法获取到异步 action 的相关数据。因此需要修改 san-store 中触发 action 的过程中 emitDevtool 的调用时机。
[异步 action 无法监听的相关代码](https://github.com/baidu/san-store/blob/05894698c8640d6c8cf92139819e2d6c94164499/src/store.js#L185)

解决方式：

经过本地修改并测试，异步 action 触发的时候，发送 store-dispatch-start 事件，在异步 action 结束之后，发送 store-dispatch-done 事件。同步的 action 同样通过 store-dispatch-done 发送数据，并删除原来的 store-dispatched 事件。当前新版 san-devtools 已做好新旧 san-store 版本的兼容。