### PR TITLE
fix: 修复 ComponentClass clone 时候缺失 enumerable 属性问题

### DIFF
--- a/src/connect/createConnector.js
+++ b/src/connect/createConnector.js
@@ -40,15 +40,9 @@ function extendsComponent(ComponentClass) {
         NewComponentClass = extendsAsFunc(ComponentClass);
     }
 
-    NewComponentClass.template = ComponentClass.template;
-    NewComponentClass.components = ComponentClass.components;
-    NewComponentClass.trimWhitespace = ComponentClass.trimWhitespace;
-    NewComponentClass.delimiters = ComponentClass.delimiters;
-    NewComponentClass.autoFillStyleAndId = ComponentClass.autoFillStyleAndId;
-    NewComponentClass.filters = ComponentClass.filters;
-    NewComponentClass.computed = ComponentClass.computed;
-    NewComponentClass.messages = ComponentClass.messages;
-
+    for (var key in ComponentClass) {
+        NewComponentClass[key] = ComponentClass[key];
+    }
     return NewComponentClass;
 }
 

--- a/test/connect.san.spec.js
+++ b/test/connect.san.spec.js
@@ -184,6 +184,8 @@ describe('Connect san component', () => {
 
         }
         RawComponent.template =  '<u title="{{name}}-{{email}}">{{name}}-{{email}}</u>';
+        RawComponent.hello = 'erik';
+        RawComponent.sayHello = function () {};
 
         let MyComponent = connect.san({
             name: 'name',
@@ -201,6 +203,9 @@ describe('Connect san component', () => {
         let u = wrap.getElementsByTagName('u')[0];
         expect(myComponent.data.get('name')).toBe('errorrik');
         expect(u.title).toBe('errorrik-errorrik@gmail.com');
+
+        expect(MyComponent.hello).not.toBeUndefined();
+        expect(MyComponent.sayHello).not.toBeUndefined();
 
         myComponent.dispose();
         document.body.removeChild(wrap);
@@ -224,6 +229,8 @@ describe('Connect san component', () => {
         }(san.Component);
         
         RawComponent.template =  '<u title="{{name}}-{{email}}">{{name}}-{{email}}</u>';
+        RawComponent.hello = 'erik';
+        RawComponent.sayHello = function () {};
 
         let MyComponent = connect.san({
             name: 'name',
@@ -241,6 +248,9 @@ describe('Connect san component', () => {
         let u = wrap.getElementsByTagName('u')[0];
         expect(myComponent.data.get('name')).toBe('errorrik');
         expect(u.title).toBe('errorrik-errorrik@gmail.com');
+
+        expect(MyComponent.hello).not.toBeUndefined();
+        expect(MyComponent.sayHello).not.toBeUndefined();
 
         myComponent.dispose();
         document.body.removeChild(wrap);
@@ -303,6 +313,8 @@ describe('Connect san component', () => {
         let RawComponent = san.defineComponent({
         });
         RawComponent.template =  '<u title="{{name}}-{{email}}">{{name}}-{{email}}</u>';
+        RawComponent.hello = 'erik';
+        RawComponent.sayHello = function () {};
 
         let MyComponent = connect.san({
             name: 'name',
@@ -319,6 +331,9 @@ describe('Connect san component', () => {
 
         let u = wrap.getElementsByTagName('u')[0];
         expect(u.title).toBe('errorrik-errorrik@gmail.com');
+
+        expect(MyComponent.hello).not.toBeUndefined();
+        expect(MyComponent.sayHello).not.toBeUndefined();
 
         myComponent.dispose();
         document.body.removeChild(wrap);

--- a/test/parse-name.spec.js
+++ b/test/parse-name.spec.js
@@ -1,4 +1,3 @@
-
 import parseName from '../src/parse-name';
 
 describe('parseName', () => {
@@ -20,8 +19,8 @@ describe('parseName', () => {
         let result = parseName('t1.t2[0]["t4"].t3')
         expect(result.length).toBe(5);
         expect(result[0]).toBe('t1');
-        expect(result[2]).toBe(0);
         expect(result[1]).toBe('t2');
+        expect(result[2]).toBe(0);
         expect(result[3]).toBe('t4');
         expect(result[4]).toBe('t3');
     });


### PR DESCRIPTION
在频道场景内，编译后会在 XXXSanComponent 上添加属性 XXXSanComponent.getANode = () => {xxxx} 作为编译优化。

按老的 extendsComponent 将会丢失 getANode 之类的 enumerable 属性。