### PR TITLE
clone Component时，增加手动clone内部属性aPack & aNode

### DIFF
--- a/src/connect/createConnector.js
+++ b/src/connect/createConnector.js
@@ -47,6 +47,8 @@ function extendsComponent(ComponentClass) {
     NewComponentClass.autoFillStyleAndId = ComponentClass.autoFillStyleAndId;
     NewComponentClass.filters = ComponentClass.filters;
     NewComponentClass.computed = ComponentClass.computed;
+    NewComponentClass.aPack = ComponentClass.aPack;
+    NewComponentClass.aNode = ComponentClass.aNode;
     NewComponentClass.messages = ComponentClass.messages;
 
     return NewComponentClass;

--- a/src/connect/createConnector.js
+++ b/src/connect/createConnector.js
@@ -48,7 +48,6 @@ function extendsComponent(ComponentClass) {
     NewComponentClass.filters = ComponentClass.filters;
     NewComponentClass.computed = ComponentClass.computed;
     NewComponentClass.aPack = ComponentClass.aPack;
-    NewComponentClass.aNode = ComponentClass.aNode;
     NewComponentClass.messages = ComponentClass.messages;
 
     return NewComponentClass;


### PR DESCRIPTION
项目中在同时升级san-ssr & san-store & 使用aPack替换template时，出现产出都正常但是页面白屏的情况，最后定位到是在san-store中clone Component手动添加内部属性时丢了aPack，所以提个PR补充一下