### PR TITLE
connect时获取当前 component 实例

### DIFF
--- a/src/connect/createConnector.js
+++ b/src/connect/createConnector.js
@@ -123,7 +123,7 @@ function connect(mapStates, mapActions, store) {
             // init data
             mapStateInfo.forEach(info => {
                 if (typeof info.getter === 'function') {
-                    this.data.set(info.dataName, info.getter(store.getState()));
+                    this.data.set(info.dataName, info.getter(store.getState(), this));
                 }
                 else {
                     this.data.set(info.dataName, store.getState(info.stateName));
@@ -134,7 +134,7 @@ function connect(mapStates, mapActions, store) {
             this.__storeListener = diff => {
                 mapStateInfo.forEach(info => {
                     if (typeof info.getter === 'function') {
-                        this.data.set(info.dataName, info.getter(store.getState()));
+                        this.data.set(info.dataName, info.getter(store.getState(), this));
                         return;
                     }
 


### PR DESCRIPTION
背景：
为了在 connect 中动态获取所需 store，现通过为 connect function 类型暴露当前 component 实例，根据当前 component 实例中属性动态获取对应 store。