### PR TITLE
fix:remove extra data in actionInfoIndex

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -332,16 +332,17 @@ export default class Store {
 
         // free actionInfos
         if (this._detectActionDone(actionInfo.parentId) == null && !this.log) {
+            if (this.actionInfos.some(actionInfo => !actionInfo.done)) {
+                return;
+            }
             let len = this.actionInfos.length;
             while (len--) {
-                if (!this.actionInfos[len].done) {
-                    return;
-                }
+                const deleteId =  this.actionInfos[len].id;
+                delete this.actionInfoIndex[deleteId];
             }
 
             this.actionInfos = [];
             this.aiLen = 0;
-            delete this.actionInfoIndex[id];
         }
 
         return true;


### PR DESCRIPTION
修复以下问题：
当store内同步action包含异步action，且异步action未使用return语句返回时，若异步action执行时间较长，此时同步action为done的状态从 actionInfos内删除，但是actionInfoIndex 未能删除，会出现根据id取出的actionInfo和实际不对应，可能导致循环。

复现代码：

```
store.addAction('changeUserName', (name, {dispatch}) => {
    dispatch('chanegX', 1);
    dispatch('changeY', 2);
});
store.addAction('chanegX', (name, {dispatch}) => {
    console.log('changeX');
    setTimeout(() => {
        console.log('setTimeout');
        dispatch('chanegZ');
    }, 1000);
});
store.addAction('changeY', (name, {dispatch}) => {
    console.log('changeY');
    return builder().set('setCount', name);
});
store.addAction('chanegZ', (name, {dispatch}) => {
    console.log('chanegZ');
    dispatch('chanegZCB');
});
store.addAction('chanegZCB', (name, {dispatch}) => {
    console.log('chanegZCB');
});
```
<img width="716" alt="e1dd6d25417bc6a9b44baab4a65151da" src="https://github.com/baidu/san-store/assets/6957407/8e61f936-e319-49e6-89b3-3fe3d2d37b97">

<img width="1366" alt="2d5c9a721a534afa7c0326460759c25c" src="https://github.com/baidu/san-store/assets/6957407/1d6c4543-2ad4-4e5e-8eb0-0aca487ad27a">

图中可见由于 actionInfoIndex内的数据残余，取出的id为7的actionInfo存在问题，在处理_detectActionDone(actionInfo.parentId) 时陷入死循环，最终导致栈溢出